### PR TITLE
Favour items in both accept header and media types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ doc/
 .yardoc
 *~
 *.sw*
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'http://rubygems.org'
+
+gemspec

--- a/lib/rack/respond_to.rb
+++ b/lib/rack/respond_to.rb
@@ -62,6 +62,8 @@ module Rack
 
       # Requested media types, in preferencial order
       #
+      # Favor items requested in HTTP_ACCEPT over the assigned media_types
+      #
       # ===== Examples
       #
       #   RespondTo.env['HTTP_ACCEPT'] #=> 'text/html,application/xml'
@@ -71,7 +73,15 @@ module Rack
       #   RespondTo.media_types        #=> ['application/xml', 'application/json', 'text/html']
       #
       def media_types
-        @media_types || accept_list
+        return @media_types unless accept_list
+        return accept_list unless @media_types
+
+        if accept_list.empty?
+          @media_types
+        else
+          types = accept_list & @media_types
+          types.empty? ? @media_types : types
+        end
       end
       alias :mime_types :media_types
 

--- a/rack-respond_to.gemspec
+++ b/rack-respond_to.gemspec
@@ -12,5 +12,6 @@ spec = Gem::Specification.new do |s|
   s.files               =  File.read("Manifest").strip.split("\n")
 
   s.add_dependency 'rack-accept-media-types', '>= 0.6'
+  s.add_dependency 'rack'
   s.add_development_dependency 'minitest'
 end

--- a/test/test_respond_to.rb
+++ b/test/test_respond_to.rb
@@ -51,6 +51,13 @@ class TestRespondTo < MiniTest::Unit::TestCase
     assert_equal %w( text/plain ), Rack::RespondTo.media_types
   end
 
+  test "explicitly specified headers in the media types take precedence over other media types" do
+    Rack::RespondTo.env = {'HTTP_ACCEPT' => 'text/html'}
+    Rack::RespondTo.media_types = %w( text/plain text/html)
+    assert_equal %w( text/html ), Rack::RespondTo.media_types
+  end
+
+
   ## respond_to
 
   test "respond_to returns block for highest ranking format" do


### PR DESCRIPTION
Currently, if media_types is provided it always overrides the accept header. With this patch, if a content type is provided in both the accept header and the media_types it will be favoured over other things in the media_types.
